### PR TITLE
Insert base type for the dimension system type for GNAT GPL 2017

### DIFF
--- a/software/hal/boards/common/tools/units.ads
+++ b/software/hal/boards/common/tools/units.ads
@@ -23,7 +23,8 @@ package Units with
    --  The unit system
    ---------------------
 
-   type Unit_Type is new Float with  -- As tagged Type? -> Generics with Unit_Type'Class
+   type Base_Unit_Type is new Float;
+   type Unit_Type is new Base_Unit_Type with  -- As tagged Type? -> Generics with Unit_Type'Class
         Dimension_System =>
         ((Unit_Name => Meter, Unit_Symbol => 'm', Dim_Symbol => 'L'),
          (Unit_Name => Kilogram, Unit_Symbol => "kg", Dim_Symbol => 'M'),
@@ -32,6 +33,9 @@ package Units with
          (Unit_Name => Kelvin, Unit_Symbol => 'K', Dim_Symbol => "Theta"),
          (Unit_Name => Radian, Unit_Symbol => "Rad", Dim_Symbol => "A")),
    Default_Value => 0.0; -- required for matrices
+
+   function Ignore_Unit (X : Unit_Type) return Unit_Type is
+     (Unit_Type (Base_Unit_Type (X)));
 
    type Unit_Array is array (Natural range <>) of Unit_Type;
 

--- a/software/lib/generic_pid_controller.adb
+++ b/software/lib/generic_pid_controller.adb
@@ -38,17 +38,17 @@ package body Generic_PID_Controller with SPARK_Mode => On is
                     dt    : Time_Type;
                     result : out PID_Output_Type) 
    is
-      derivate     : Unit_Type := 0.0;
-      output       : Unit_Type := Unit_Type( 0.0 );
-      tmp_integral : Unit_Type := 0.0;
+      derivate     : Base_Unit_Type := 0.0;
+      output       : Base_Unit_Type := 0.0;
+      tmp_integral : Base_Unit_Type := 0.0;
    begin
    
       -- Intetgral Part
-      tmp_integral := Unit_Type(Pid.Integral) + Unit_Type(error) * Unit_Type(dt);
-      if tmp_integral in  Unit_Type(Pid.I_Limit_Low) .. Unit_Type(Pid.I_Limit_High) then
+      tmp_integral := Base_Unit_Type(Pid.Integral) + Base_Unit_Type(error) * Base_Unit_Type(dt);
+      if tmp_integral in  Base_Unit_Type(Pid.I_Limit_Low) .. Base_Unit_Type(Pid.I_Limit_High) then
          Pid.Integral := PID_Integral_Type( tmp_integral );
       else
-         if tmp_integral <  Unit_Type(Pid.I_Limit_Low) then
+         if tmp_integral <  Base_Unit_Type(Pid.I_Limit_Low) then
             Pid.Integral := Pid.I_Limit_Low;
          else 
             Pid.Integral := Pid.I_Limit_High;
@@ -56,21 +56,21 @@ package body Generic_PID_Controller with SPARK_Mode => On is
       end if;   
 
       -- Derivate Part
-      derivate := Unit_Type(error - Pid.Previous_Error) / Unit_Type( dt );
+      derivate := Base_Unit_Type(error - Pid.Previous_Error) / Base_Unit_Type( dt );
       Pid.Previous_Error := error;
       
       
       -- Calculate Output with Gains
-      output := Unit_Type( Pid.Kp ) * Unit_Type( error ) +
-                Unit_Type( Pid.Ki ) * Unit_Type( Pid.Integral ) +
-                Unit_Type( Pid.Kd ) * derivate;
+      output := Base_Unit_Type( Pid.Kp ) * Base_Unit_Type( error ) +
+                Base_Unit_Type( Pid.Ki ) * Base_Unit_Type( Pid.Integral ) +
+                Base_Unit_Type( Pid.Kd ) * derivate;
       
       
       -- Saturate Output
-      if output < Unit_Type( Pid.Output_Limit_Low ) then
-         output := Unit_Type( Pid.Output_Limit_Low );
-      elsif output > Unit_Type(Pid.Output_Limit_High) then
-         output := Unit_Type( Pid.Output_Limit_High );
+      if output < Base_Unit_Type( Pid.Output_Limit_Low ) then
+         output := Base_Unit_Type( Pid.Output_Limit_Low );
+      elsif output > Base_Unit_Type(Pid.Output_Limit_High) then
+         output := Base_Unit_Type( Pid.Output_Limit_High );
       end if;
 
       result := PID_Output_Type( output );

--- a/software/lib/units-navigation.ads
+++ b/software/lib/units-navigation.ads
@@ -109,7 +109,7 @@ package Units.Navigation with SPARK_Mode is
 
 
    function To_NED_Translation( value : GPS_Translation_Type) return NED_Translation_Vector is
-   ( DIM_NORTH => Cos(value.Latitude) * value.Longitude * METER_PER_LAT_DEGREE,
+   ( DIM_NORTH => Unit_Type(Cos(value.Latitude)) * value.Longitude * METER_PER_LAT_DEGREE,
       DIM_EAST => value.Latitude * METER_PER_LAT_DEGREE,
       DIM_DOWN => -(value.Altitude) );
 

--- a/software/lib/units-numerics.adb
+++ b/software/lib/units-numerics.adb
@@ -4,9 +4,9 @@ package body Units.Numerics with
    SPARK_Mode => On
 is
 
-   function Sqrt (X : Unit_Type) return Unit_Type is
+   function Sqrt (X : Base_Unit_Type) return Base_Unit_Type is
    begin
-      return Unit_Type (Elementary_Functions.Sqrt (Float (X)));
+      return Base_Unit_Type( Elementary_Functions.Sqrt (Float (X)) );
    end Sqrt;
 
 --     procedure Lemma_Log_Is_Monotonic (X, Y : Unit_Type) with
@@ -19,63 +19,61 @@ is
 --      is null with SPARK_Mode => Off;
 
 
-   function Exp (X : Unit_Type) return Unit_Type is
+   function Exp (X : Base_Unit_Type) return Base_Unit_Type is
    begin
-      return Unit_Type (Elementary_Functions.Exp (Float (X)));
+      return Base_Unit_Type (Elementary_Functions.Exp (Float (X)));
    end Exp;
 
 
-   function Log (X : Unit_Type) return Unit_Type is
+   function Log (X : Base_Unit_Type) return Base_Unit_Type is
    begin
-      return Unit_Type (Elementary_Functions.Log (Float (X)));
+      return Base_Unit_Type (Elementary_Functions.Log (Float (X)));
    end Log;
 
 
-   function "**" (Left : Unit_Type; Right : Float) return Unit_Type is
+   function "**" (Left : Base_Unit_Type; Right : Float) return Base_Unit_Type is
    begin
       -- Elementary_Functions does not offer Pow, and "**" is for Natural exponents only.
       -- Thus: x=b**y => log_b(x)=y => log x/log b = y => log x = log b*y => x=exp(y*log b)
       -- with b=left, y=right
       declare
-         ll  : constant Unit_Type := Log (Left);
-         arg : constant Unit_Type := Unit_Type (Right) * ll; -- TODO: ovf check might fail
+         ll  : constant Base_Unit_Type := Log (Left);
+         arg : constant Base_Unit_Type := Base_Unit_Type (Right) * ll; -- TODO: ovf check might fail
       begin
-         pragma Assert (arg < Log (Unit_Type'Last)); -- TODO: assertion fails
-         return Unit_Type (Exp (arg));
+         pragma Assert (arg < Log (Base_Unit_Type'Last)); -- TODO: assertion fails
+         return Base_Unit_Type (Exp (arg));
       end;
    end "**";
 
-
-   function Sin (X : Angle_Type) return Unit_Type is
+   function Sin (X : Angle_Type) return Base_Unit_Type is
    begin
-      return Unit_Type (Elementary_Functions.Sin (Float (X)));
+      return Base_Unit_Type( Elementary_Functions.Sin( Float( X ) ) );
    end Sin;
-
 
    -- header comment for Cos
    -- @req mine+2
-   function Cos (X : Angle_Type) return Unit_Type is
+   function Cos (X : Angle_Type) return Base_Unit_Type is
    begin
-      -- @req foobar/2 @req nothing
+      --  @req foobar/2 @req nothing
       -- @req foobar/2
-      return Unit_Type (Elementary_Functions.Cos (Float (X)));
+      return Base_Unit_Type( Elementary_Functions.Cos( Float( X ) ) );
    end Cos;
    -- footer comment for cos
 
 
+
    function Arctan
-     (Y     : Unit_Type'Base;
-      X     : Unit_Type'Base := 1.0;
+     (Y     : Base_Unit_Type'Base;
+      X     : Base_Unit_Type'Base := 1.0;
       Cycle : Angle_Type)
       return Angle_Type is
    begin
       return Angle_Type (Elementary_Functions.Arctan (Y => Float (Y), X => Float (X), Cycle => Float (Cycle)));
    end Arctan;
 
-
    function Arctan
-     (Y : Unit_Type;
-      X : Unit_Type := 1.0)
+     (Y : Base_Unit_Type;
+      X : Base_Unit_Type := 1.0)
       return Angle_Type is
    begin
       return Angle_Type (Elementary_Functions.Arctan (Y => Float (Y), X => Float (X)));

--- a/software/lib/units-numerics.ads
+++ b/software/lib/units-numerics.ads
@@ -1,18 +1,18 @@
---  Description: Wrapper to use Unit_Type with a-nuelfu
+--  Description: Wrapper to use Base_Unit_Type with a-nuelfu
 --  TODO: all the postconditions are unproven, because a-nuelfu
 --  builds on the generic C math interface
 --  however, instead of modifying the RTS, we add them here and
 --  leave them unproven (hoping the RTS introduces contracts later on)
 package Units.Numerics with SPARK_Mode is
    
-   function Sqrt (X : Unit_Type) return Unit_Type with 
+   function Sqrt (X : Base_Unit_Type) return Base_Unit_Type with 
      Pre => X >= 0.0,
      Contract_Cases => ((X >= 0.0 and then X < 1.0) => Sqrt'Result >= X,
                         (X >= 1.0) => Sqrt'Result <= X),
      Post => Sqrt'Result >= 0.0;
     
    
-   function Log (X : Unit_Type) return Unit_Type with 
+   function Log (X : Base_Unit_Type) return Base_Unit_Type with 
      Pre => X > 0.0,
      Contract_Cases => ((X <= 1.0) => Log'Result <= 0.0,
                         (X > 1.0)  => Log'Result >= 0.0),
@@ -21,29 +21,29 @@ package Units.Numerics with SPARK_Mode is
    --  FIXME: very weak contract (magnitude of result could be approximated)
    
    
-   function Exp (X : Unit_Type) return Unit_Type with 
-     Pre => X <= Log (Unit_Type'Last),       
+   function Exp (X : Base_Unit_Type) return Base_Unit_Type with 
+     Pre => X <= Log (Base_Unit_Type'Last),       
      Post => Exp'Result >= 0.0; -- allow rounding
    --  return the base-e exponential function of <X>, i.e., e**X
    
    
-   function "**" (Left : Unit_Type; Right : Float) return Unit_Type
+   function "**" (Left : Base_Unit_Type; Right : Float) return Base_Unit_Type
      with Pre => Left > 0.0;
    -- FIXME: change implementation to allow negative base
 
    
-   function Sin (X : Angle_Type) return Unit_Type with
+   function Sin (X : Angle_Type) return Base_Unit_Type with
      Post => Sin'Result in -1.0 .. 1.0;   
 
    
    -- @req cosine-x
-   function Cos (X : Angle_Type) return Unit_Type with
+   function Cos (X : Angle_Type) return Base_Unit_Type with
      Post => Cos'Result in -1.0 .. 1.0;
 
          
    function Arctan
-     (Y : Unit_Type;
-      X : Unit_Type := 1.0) return Angle_Type with 
+     (Y : Base_Unit_Type;
+      X : Base_Unit_Type := 1.0) return Angle_Type with 
      Pre => X /= 0.0 or Y /= 0.0,
      Contract_Cases => ( Y >= 0.0 => Arctan'Result in    0.0 * Degree .. 180.0 * Degree,
                          Y <  0.0 => Arctan'Result in -180.0 * Degree .. 0.0 * Degree);
@@ -52,45 +52,45 @@ package Units.Numerics with SPARK_Mode is
 
    
    function Arctan
-     (Y     : Unit_Type'Base;
-      X     : Unit_Type'Base := 1.0;
+     (Y     : Base_Unit_Type'Base;
+      X     : Base_Unit_Type'Base := 1.0;
       Cycle : Angle_Type) return Angle_Type with
      Post => Arctan'Result in -Cycle/2.0 .. Cycle/2.0;
    --  Calculates angle to point y,x, but wraps the result into the given cycle
          
    
 --     function Arccot
---       (X : Unit_Type;
---        Y : Unit_Type := 1.0) return Angle_Type;
+--       (X : Base_Unit_Type;
+--        Y : Base_Unit_Type := 1.0) return Angle_Type;
 --              
 --     function Arccot
---       (X     : Unit_Type;
---        Y     : Unit_Type := 1.0;
+--       (X     : Base_Unit_Type;
+--        Y     : Base_Unit_Type := 1.0;
 --        Cycle : Angle_Type) return Angle_Type;
 --              
---     function Arcsin (X : Angle_Type) return Unit_Type  
+--     function Arcsin (X : Angle_Type) return Base_Unit_Type  
 --       with Post => Arcsin'Result in -90.0*Degree .. 90.0*Degree;
 --  
---     function Cos (X, Cycle : Angle_Type) return Unit_Type;
+--     function Cos (X, Cycle : Angle_Type) return Base_Unit_Type;
 --           
---     function Tan (X : Angle_Type) return Unit_Type;
+--     function Tan (X : Angle_Type) return Base_Unit_Type;
 --           
---     function Tan (X, Cycle : Angle_Type) return Unit_Type;
+--     function Tan (X, Cycle : Angle_Type) return Base_Unit_Type;
 --           
---     function Cot (X : Angle_Type) return Unit_Type;
+--     function Cot (X : Angle_Type) return Base_Unit_Type;
 --           
---     function Cot (X, Cycle : Angle_Type) return Unit_Type;
+--     function Cot (X, Cycle : Angle_Type) return Base_Unit_Type;
 --           
---     function Arcsin (X : Unit_Type) return Angle_Type;
+--     function Arcsin (X : Base_Unit_Type) return Angle_Type;
 --           
---     function Arcsin (X : Unit_Type; Cycle : Angle_Type) return Angle_Type;
+--     function Arcsin (X : Base_Unit_Type; Cycle : Angle_Type) return Angle_Type;
 --              
---     function Arccos (X  : Unit_Type) return Angle_Type;
+--     function Arccos (X  : Base_Unit_Type) return Angle_Type;
 --           
---     function Arccos  (X : Unit_Type; Cycle : Angle_Type) return Angle_Type;
+--     function Arccos  (X : Base_Unit_Type; Cycle : Angle_Type) return Angle_Type;
 --  
---     function Exp (X : Unit_Type) return Float;
+--     function Exp (X : Base_Unit_Type) return Float;
 --     
---     function Log (X : Unit_Type) return Float;
+--     function Log (X : Base_Unit_Type) return Float;
    
 end Units.Numerics;

--- a/software/lib/units-vectors.adb
+++ b/software/lib/units-vectors.adb
@@ -4,13 +4,13 @@ pragma Elaborate_All(Units);
 
 package body Units.Vectors with SPARK_Mode is
 
-   function Sat_Add is new Saturated_Addition (Unit_Type);
-   function Sat_Sub is new Saturated_Subtraction (Unit_Type);
+   function Sat_Add is new Saturated_Addition (Base_Unit_Type);
+   function Sat_Sub is new Saturated_Subtraction (Base_Unit_Type);
 
-   function Unit_Square (val : Unit_Type) return Unit_Type is
+   function Unit_Square (val : Base_Unit_Type) return Base_Unit_Type is
    begin
-      if Sqrt (Unit_Type'Last) <= abs (val) then
-         return Unit_Type'Last;
+      if Sqrt (Base_Unit_Type'Last) <= abs (val) then
+         return Base_Unit_Type'Last;
       else
          return val*val; -- TODO: fails (Sqrt is not modeled precisely)
       end if;
@@ -23,8 +23,8 @@ package body Units.Vectors with SPARK_Mode is
    is
       result : Cartesian_Vector_Type := vector;
 
-      co : constant Unit_Type := Cos (angle);
-      si : constant Unit_Type := Sin (angle);
+      co : constant Base_Unit_Type := Cos (angle);
+      si : constant Base_Unit_Type := Sin (angle);
       pragma Assert (co in -1.0 .. 1.0);
       pragma Assert (si in -1.0 .. 1.0);
    begin
@@ -44,31 +44,31 @@ package body Units.Vectors with SPARK_Mode is
       vector := result;
    end rotate;
 
-   function "abs" (vector : Cartesian_Vector_Type) return Unit_Type is
-      xx : constant Unit_Type := Unit_Square (vector(X));
-      yy : constant Unit_Type := Unit_Square (vector(Y));
-      zz : constant Unit_Type := Unit_Square (vector(Z));
-      len : constant Unit_type := Sat_Add (Sat_Add (xx, yy), zz);
+   function "abs" (vector : Cartesian_Vector_Type) return Base_Unit_Type is
+      xx : constant Base_Unit_Type := Unit_Square (vector(X));
+      yy : constant Base_Unit_Type := Unit_Square (vector(Y));
+      zz : constant Base_Unit_Type := Unit_Square (vector(Z));
+      len : constant Base_Unit_Type := Sat_Add (Sat_Add (xx, yy), zz);
       pragma Assert (len >= 0.0); -- TODO: fails. need lemma?
    begin
       return Sqrt (len);
    end "abs";
 
-   function "abs" (vector : Angular_Vector) return Unit_Type is
-      xx : constant Unit_Type := Unit_Square (vector(X));
-      yy : constant Unit_Type := Unit_Square (vector(Y));
-      zz : constant Unit_Type := Unit_Square (vector(Z));
-      len : constant Unit_type := Sat_Add (Sat_Add (xx, yy), zz);
+   function "abs" (vector : Angular_Vector) return Base_Unit_Type is
+      xx : constant Base_Unit_Type := Unit_Square (vector(X));
+      yy : constant Base_Unit_Type := Unit_Square (vector(Y));
+      zz : constant Base_Unit_Type := Unit_Square (vector(Z));
+      len : constant Base_Unit_Type := Sat_Add (Sat_Add (xx, yy), zz);
       pragma Assert (len >= 0.0); -- TODO: fails. need lemma?
    begin
       return Sqrt (len);
    end "abs";
 
    function "abs" (vector : Linear_Acceleration_Vector) return Linear_Acceleration_Type is
-      xx : constant Unit_Type := Unit_Square (vector(X));
-      yy : constant Unit_Type := Unit_Square (vector(Y));
-      zz : constant Unit_Type := Unit_Square (vector(Z));
-      len : constant Unit_type := Sat_Add (Sat_Add (xx, yy), zz);
+      xx : constant Base_Unit_Type := Unit_Square (Base_Unit_Type (vector(X)));
+      yy : constant Base_Unit_Type := Unit_Square (Base_Unit_Type (vector(Y)));
+      zz : constant Base_Unit_Type := Unit_Square (Base_Unit_Type (vector(Z)));
+      len : constant Base_Unit_Type := Sat_Add (Sat_Add (xx, yy), zz);
       pragma Assert (len >= 0.0); -- TODO: fails. need lemma?
    begin
       return Linear_Acceleration_Type (Sqrt (len));

--- a/software/lib/units-vectors.ads
+++ b/software/lib/units-vectors.ads
@@ -14,10 +14,10 @@ with Ada.Numerics.Generic_Real_Arrays;
 
 package Units.Vectors with SPARK_Mode is
 
-   package Unit_Arrays_Pack is new Ada.Numerics.Generic_Real_Arrays(Unit_Type);
+   package Unit_Arrays_Pack is new Ada.Numerics.Generic_Real_Arrays(Base_Unit_Type);
 
-   subtype Scalar is Unit_Type;
-   type Vector3D_Type is array(1 .. 3) of Unit_Type;
+   subtype Scalar is Base_Unit_Type;
+   type Vector3D_Type is array(1 .. 3) of Base_Unit_Type;
 
 
    type Polar_Coordinates_Type is (Phi, Rho, Psi);
@@ -25,13 +25,13 @@ package Units.Vectors with SPARK_Mode is
 
 
    type Cartesian_Coordinates_Type is (X, Y, Z);
-   type Cartesian_Vector_Type is array(Cartesian_Coordinates_Type) of Unit_Type'Base;
+   type Cartesian_Vector_Type is array(Cartesian_Coordinates_Type) of Base_Unit_Type;
 
 
    subtype Translation_Vector_Array is Vector3D_Type; -- of Length_Type;
 
    --subtype Position_Vector is Karthesian_Vector_Type with Dimension => (Symbol => 'm', Meter => 1, others => 0);
---     type Dim_Vector_Type is array(Cartesian_Coordinates_Type) of Unit_Type with Dimension_System =>
+--     type Dim_Vector_Type is array(Cartesian_Coordinates_Type) of Base_Unit_Type with Dimension_System =>
 --          ((Unit_Name => Meter, Unit_Symbol => 'm', Dim_Symbol => 'L'),
 --           (Unit_Name => Kilogram, Unit_Symbol => "kg", Dim_Symbol => 'M'),
 --           (Unit_Name => Second, Unit_Symbol => 's', Dim_Symbol => 'T'),
@@ -60,7 +60,7 @@ package Units.Vectors with SPARK_Mode is
    type Tait_Bryan_Angle_Type is (ROLL, PITCH, YAW);
    type Euler_Angle_Type is (X1, Z2, X3);
 
-   type Angular_Vector is array(Cartesian_Coordinates_Type) of Unit_Type;
+   type Angular_Vector is array(Cartesian_Coordinates_Type) of Base_Unit_Type;
 
    type Unit_Vector is array(Tait_Bryan_Angle_Type) of Angle_Type;
 
@@ -83,8 +83,8 @@ package Units.Vectors with SPARK_Mode is
    function "+" (Left, Right : Rotation_Vector) return Rotation_Vector is
       ( Left(X) + Right(X), Left(Y) + Right(Y), Left(Z) + Right(Z) );
 
-   function "*" (Left : Unit_Type; Right : Rotation_Vector) return Rotation_Vector is
-      ( ( Left * Right(X), Left * Right(Y), Left * Right(Z) ) );
+   function "*" (Left : Base_Unit_Type; Right : Rotation_Vector) return Rotation_Vector is
+      ( ( Unit_Type(Left) * Right(X), Unit_Type(Left) * Right(Y), Unit_Type(Left) * Right(Z) ) );
 
 
    function "+" (Left, Right : Angular_Velocity_Vector) return Angular_Velocity_Vector is
@@ -106,15 +106,15 @@ package Units.Vectors with SPARK_Mode is
       ( ( Left(X) * Right, Left(Y) * Right, Left(Z) * Right ) );
 
 
-   function Unit_Square (val : Unit_Type) return Unit_Type with
-     Post => Unit_Square'Result >= Unit_Type (0.0);
+   function Unit_Square (val : Base_Unit_Type) return Base_Unit_Type with
+     Post => Unit_Square'Result >= Base_Unit_Type (0.0);
    --  numerically safe power val*val
 
    procedure rotate(vector : in out Cartesian_Vector_Type; axis : Cartesian_Coordinates_Type; angle : Angle_Type);
 
-   function "abs" (vector : Cartesian_Vector_Type) return Unit_Type;
+   function "abs" (vector : Cartesian_Vector_Type) return Base_Unit_Type;
 
-   function "abs" (vector : Angular_Vector) return Unit_Type;
+   function "abs" (vector : Angular_Vector) return Base_Unit_Type;
 
 
    function "abs" (vector : Linear_Acceleration_Vector) return Linear_Acceleration_Type;
@@ -126,8 +126,8 @@ package Units.Vectors with SPARK_Mode is
 
 
 
-   type Unit_Vector2D is array(1..2) of Unit_Type;
-   type Unit_Matrix2D is array(1..2, 1..2) of Unit_Type;
+   type Unit_Vector2D is array(1..2) of Base_Unit_Type;
+   type Unit_Matrix2D is array(1..2, 1..2) of Base_Unit_Type;
 
    -- subtype Unit_Vector2D is Unit_Arrays_Pack.Real_Vector(1..2);
    --subtype Unit_Vector3D is Unit_Arrays_Pack.Real_Vector(1..3);

--- a/software/modules/estimator.adb
+++ b/software/modules/estimator.adb
@@ -545,12 +545,12 @@ package body Estimator with SPARK_Mode is
          -- Arctan: Only X = Y = 0 raises exception
          -- Output range: -Cycle/2.0 to Cycle/2.0, thus -180° to 180°
          angles.Roll  := Roll_Type ( Arctan(
-                                     -gravity_vector(Y),   -- minus
-                                     -gravity_vector(Z)
+                                     Base_Unit_Type (-gravity_vector(Y)),   -- minus
+                                     Base_Unit_Type (-gravity_vector(Z))
                                       ) );
 
          g_length := Sqrt (Sat_Add_Float (Float (gravity_vector(Y))**2, Float (gravity_vector(Z))**2));
-         angles.Pitch := Sat_Cast_Pitch (Float (Arctan (gravity_vector(X), Linear_Acceleration_Type (g_length))));
+         angles.Pitch := Sat_Cast_Pitch (Float (Arctan (Base_Unit_Type (gravity_Vector(X)), Base_Unit_Type (Linear_Acceleration_Type (g_length)))));
          angles.Yaw := 0.0 * Degree;
 
       end if;

--- a/software/modules/sensors/barometer.adb
+++ b/software/modules/sensors/barometer.adb
@@ -42,11 +42,11 @@ is
       p_ref   : constant Pressure_Type := 1013.25 * Hecto * Pascal;
       exp_frac  : constant Float := 1.0 / 5.255;
       h0   : constant Length_Type := t_ref / t_coeff;
-      prel : constant Unit_Type := pressure / p_ref;
-      comp : constant Unit_Type := prel**exp_frac; -- TODO: ovf check might fail
-      neg  : constant Unit_Type := 1.0 - comp;
+      prel : constant Base_Unit_Type := Base_Unit_Type(pressure / P_Ref);
+      comp : constant Base_Unit_Type := prel**exp_frac; -- TODO: ovf check might fail
+      neg  : constant Base_Unit_Type := 1.0 - comp;
    begin
-      return h0 * neg; -- FIXME: overflow check might fail
+      return h0 * Unit_Type(Neg); -- FIXME: overflow check might fail
    end Altitude;
 
    function get_Altitude(Self : Barometer_Tag) return Length_Type is


### PR DESCRIPTION
Improvements in the dimension system in GNAT GPL 2017 mean that some
previously valid type conversions are now seen as invalid because the
dimensions are not forgotten anymore. Insert a type Base_Unit_Type for
the basis of Unit_Type, so that conversions to Base_Unit_Type remove
the dimensions, while conversions to Unit_Type (the root of the dimension
system) preserve dimensions.

The resulting code is compilable both with GNAT GPL 2016, and will be
compilable with GNAT GPL 2017 with an adapted runtime. (The current
runtime is specific to GNAT GPL 2016.)